### PR TITLE
add missing dependency

### DIFF
--- a/huey.gemspec
+++ b/huey.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('eventmachine', '>=1.0.0')
   s.add_dependency('httparty', '>=0.9.0')
   s.add_dependency('chronic', '>=0.9.0')
+  s.add_dependency('color', '>= 1.4.1')
 
   s.add_development_dependency('bundler', '>=0')
   s.add_development_dependency('yard', '>=0.8.3')


### PR DESCRIPTION
In both MRI 1.9.3-p385 and 2.0.0-p0 I get this:

``` shell
irb(main):001:0> require 'huey'
LoadError: cannot load such file -- color
```

It appears you are missing a gem dependency.
