### PR TITLE
lars.krantz@alaz.se

### DIFF
--- a/huey.gemspec
+++ b/huey.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency('httparty', '>=0.9.0')
   s.add_dependency('chronic', '>=0.9.0')
   s.add_dependency('color', '>= 1.4.1')
+  s.add_dependency('multi_json', '~> 1.8')
 
   s.add_development_dependency('bundler', '>=0')
   s.add_development_dependency('yard', '>=0.8.3')

--- a/lib/huey.rb
+++ b/lib/huey.rb
@@ -6,6 +6,7 @@ require 'httparty'
 require 'color'
 require 'yaml'
 require 'chronic'
+require 'multi_json'
 
 require 'huey/version'
 


### PR DESCRIPTION
Hello!
I suddenly started to get "/lib/huey/bulb.rb:56:in `save': uninitialized constant Huey::Bulb::MultiJson (NameError)" in Huey.
Forking and running tests confirmed it:
![Failing tests](https://f.cloud.github.com/assets/482247/1418405/dcd0ab88-3fb3-11e3-8f9e-9b7637b2ef19.png)

The patch is simply an added dependency and require for multi_json.

Thanks for a great gem!
/Lars Krantz
