### PR TITLE
Accommodate specification of custom port numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ pkg/
 tmp/
 
 */.DS_Store
+
+.ruby-version
+.ruby-gemset

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,31 @@
 PATH
   remote: .
   specs:
-    huey (1.2.0)
+    huey (2.0.0)
       chronic (>= 0.9.0)
       color (>= 1.4.1)
       eventmachine (>= 1.0.0)
       httparty (>= 0.9.0)
+      multi_json (~> 1.8)
 
 GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.3.2)
     chronic (0.9.1)
-    color (1.4.1)
+    color (1.4.2)
     color-tools (1.3.0)
     crack (0.3.1)
     eventmachine (1.0.3)
-    httparty (0.10.2)
-      multi_json (~> 1.0)
+    httparty (0.12.0)
+      json (~> 1.8)
       multi_xml (>= 0.5.2)
+    json (1.8.1)
     metaclass (0.0.1)
     mocha (0.13.1)
       metaclass (~> 0.0.1)
-    multi_json (1.7.2)
-    multi_xml (0.5.3)
+    multi_json (1.8.2)
+    multi_xml (0.5.5)
     rake (0.9.5)
     timecop (0.5.9.2)
     webmock (1.9.0)

--- a/lib/huey/config.rb
+++ b/lib/huey/config.rb
@@ -14,6 +14,7 @@ module Huey #:nodoc
     option :ssdp_port, default: 1900
     option :ssdp_ttl, default: 1
     option :hue_ip, default: nil
+    option :hue_port, default: 80
     option :uuid, default: '0123456789abdcef0123456789abcdef'
 
     # The default logger for Huey: either the Rails logger or just stdout.

--- a/lib/huey/request.rb
+++ b/lib/huey/request.rb
@@ -7,7 +7,7 @@ module Huey
       [:get, :post, :put, :delete].each do |method|
         define_method(method) do |url = '', options = {}|
           response = HTTParty.send(method,
-            "http://#{self.hue_ip}/api/#{Huey::Config.uuid}/#{url}",
+            "http://#{self.hue_ip}:#{Huey::Config.hue_port}/api/#{Huey::Config.uuid}/#{url}",
             options).parsed_response
 
           if self.error?(response, 1)

--- a/lib/huey/request.rb
+++ b/lib/huey/request.rb
@@ -20,7 +20,7 @@ module Huey
       end
 
       def register
-        response = HTTParty.post("http://#{self.hue_ip}/api",
+        response = HTTParty.post("http://#{self.hue_ip}:#{Huey::Config.hue_port}/api",
           body: MultiJson.dump({username: Huey::Config.uuid,
                                 devicetype: 'Huey'})).parsed_response
 

--- a/test/unit/request_test.rb
+++ b/test/unit/request_test.rb
@@ -47,4 +47,14 @@ class RequestTest < Test::Unit::TestCase
 
     Huey::Config.hue_ip = nil
   end
+
+  def test_uses_configured_ip_
+    Huey::Config.hue_port = 12345
+
+    stub_request(:any, "http://0.0.0.0:12345/api/0123456789abdcef0123456789abcdef/")
+    Huey::Request.get
+
+    assert_requested :get, "http://0.0.0.0:12345/api/0123456789abdcef0123456789abcdef/"
+  end
+
 end


### PR DESCRIPTION
Allow for an optional custom port number to be defined. This is especially useful when connecting to a Hue Bridge from an external network via port forwarding.
