### PR TITLE
Add support for Bulb#find_all to accept multiple IDs

### DIFF
--- a/lib/huey/bulb.rb
+++ b/lib/huey/bulb.rb
@@ -23,9 +23,13 @@ module Huey
       self.all.find {|b| b.id == id || b.name == id.to_s}
     end
 
-    def self.find_all(id)
+    def self.find_all(id_or_ids)
       group = Huey::Group.new
-      self.all.select {|b| b.id == id || b.name.include?(id.to_s)}.each {|b| group.bulbs << b}
+      if id_or_ids.is_a? Array
+        self.all.select {|b| id_or_ids.include? b.id}.each {|b| group.bulbs << b}
+      else
+        self.all.select {|b| b.id == id_or_ids || b.name.include?(id_or_ids.to_s)}.each {|b| group.bulbs << b}
+      end
       group
     end
 


### PR DESCRIPTION
Given that `Bulb#find_all` creates a group with bulbs, it is convenient to be able to add multiple lights at once.  This is already possible using the partial name yet, but not by just given several IDs.
