### PR TITLE
Event with bulb bulbs group

### DIFF
--- a/lib/huey/event.rb
+++ b/lib/huey/event.rb
@@ -2,7 +2,8 @@
 
 module Huey
 
-  # An event encapsulates logic to send to a group, either at a certain time or arbitrarily
+  # An event encapsulates logic to send to a single bulb, a set of bulbs,
+  # or a group, either at a certain time or arbitrarily
   class Event
     attr_accessor :group, :bulbs, :bulb, :at, :actions, :name
 


### PR DESCRIPTION
Add support for loading events that are not associated with a group, but with a single or set of bulbs.
