### PR TITLE
Fix for Huey::Errors::HueResponseError: [{"error"=>{"type"=>6, "address"=>"/username", "description"=>"parameter, username, not available"}}] error

### DIFF
--- a/lib/huey/request.rb
+++ b/lib/huey/request.rb
@@ -21,8 +21,7 @@ module Huey
 
       def register
         response = HTTParty.post("http://#{self.hue_ip}:#{Huey::Config.hue_port}/api",
-          body: MultiJson.dump({username: Huey::Config.uuid,
-                                devicetype: 'Huey'})).parsed_response
+          body: MultiJson.dump({devicetype: 'Huey'})).parsed_response
 
         raise Huey::Errors::PressLinkButton, 'Press the link button and try your request again' if self.error?(response, 101)
 

--- a/test/unit/request_test.rb
+++ b/test/unit/request_test.rb
@@ -20,7 +20,7 @@ class RequestTest < MiniTest::Test
 
   def test_attempt_authentication_upon_failure
     stub_request(:get, "http://0.0.0.0/api/0123456789abdcef0123456789abcdef/").to_return(body: MultiJson.dump([{"error"=>{"type"=>1, "address"=>"/", "description"=>"unauthorized user"}}]), headers: {"Content-Type" => 'application/json'})
-    stub_request(:post, "http://0.0.0.0/api").with(body: MultiJson.dump({username: '0123456789abdcef0123456789abcdef', devicetype: 'Huey'})).to_return(body: MultiJson.dump([{"error"=>{"type"=>101, "address"=>"", "description"=>"link button not pressed"}}]), headers: {"Content-Type" => 'application/json'})
+    stub_request(:post, "http://0.0.0.0/api").with(body: MultiJson.dump({devicetype: 'Huey'})).to_return(body: MultiJson.dump([{"error"=>{"type"=>101, "address"=>"", "description"=>"link button not pressed"}}]), headers: {"Content-Type" => 'application/json'})
 
     assert_raises Huey::Errors::PressLinkButton do
       Huey::Request.get


### PR DESCRIPTION
Philips deprecated sending a username when registering, so attempting to register Huey with a bridge running a new firmware version will lead to that message.

The fix is to drop the username from the request.
