### PR TITLE
No longer request username in Request.register

### DIFF
--- a/lib/huey/request.rb
+++ b/lib/huey/request.rb
@@ -21,8 +21,7 @@ module Huey
 
       def register
         response = HTTParty.post("http://#{self.hue_ip}:#{Huey::Config.hue_port}/api",
-          body: MultiJson.dump({username: Huey::Config.uuid,
-                                devicetype: 'Huey'})).parsed_response
+          body: MultiJson.dump({devicetype: 'Huey'})).parsed_response
 
         raise Huey::Errors::PressLinkButton, 'Press the link button and try your request again' if self.error?(response, 101)
 


### PR DESCRIPTION
Ref https://developers.meethue.com/documentation/configuration-api the Philips Hue API has deprecated `username` in the configuration API.

This should help new users adopt the lib more quickly and encounter their own yak shaving 👍  

This PR moves to remove `username` from the `Huey::Request.register` method. 